### PR TITLE
Refactor upperBound() and lowerBound() methods

### DIFF
--- a/Assignment3/assignment3/src/ArrayNumberSequence.java
+++ b/Assignment3/assignment3/src/ArrayNumberSequence.java
@@ -48,36 +48,24 @@ public class ArrayNumberSequence implements NumberSequence
 
 	@Override
 	public double upperBound() {
-		if (isDecreasing()){
-			return numbers[0];
-		} else if (isIncreasing()) {
-			return numbers[numbers.length - 1];
-		} else {
-			double max = numbers[0];
-			for (double number : numbers) {
-				if (number > max) {
-					max = number;
-				}
+		double max = numbers[0];
+		for (double number : numbers) {
+			if (number > max) {
+				max = number;
 			}
-			return max;
 		}
+		return max;
 	}
 
 	@Override
 	public double lowerBound() {
-		if (isIncreasing()) {
-			return numbers[0];
-		} else if (isDecreasing()){
-			return numbers[numbers.length - 1];
-		} else {
-			double min = numbers[0];
-			for (double number : numbers) {
-				if (number < min) {
-					min = number;
-				}
+		double min = numbers[0];
+		for (double number : numbers) {
+			if (number < min) {
+				min = number;
 			}
-			return min;
 		}
+		return min;
 	}
 
 	@Override

--- a/Assignment3/assignment3/src/LinkedNumberSequence.java
+++ b/Assignment3/assignment3/src/LinkedNumberSequence.java
@@ -77,36 +77,28 @@ public class LinkedNumberSequence implements NumberSequence
 
 	@Override
 	public double upperBound() {
-		if (isDecreasing()) {
-			return first.number;
-		} else {
-			double max = first.number;
-			Node n = first;
-			while (n != null) {
-				if (n.number > max) {
-					max = n.number;
-				}
-				n = n.next;
+		double max = first.number;
+		Node n = first;
+		while (n != null) {
+			if (n.number > max) {
+				max = n.number;
 			}
-			return max;
+			n = n.next;
 		}
+		return max;
 	}
 
 	@Override
 	public double lowerBound() {
-		if (isIncreasing()) {
-			return first.number;
-		} else {
-			double min = first.number;
-			Node n = first;
-			while (n != null) {
-				if (n.number < min) {
-					min = n.number;
-				}
-				n = n.next;
+		double min = first.number;
+		Node n = first;
+		while (n != null) {
+			if (n.number < min) {
+				min = n.number;
 			}
-			return min;
+			n = n.next;
 		}
+		return min;
 	}
 
 	@Override


### PR DESCRIPTION
# [Bug fix]: Refactored methods upperBound() and lowerBound in ArrayNumberSequence and LinkedNumberSequence

Removed unneccesary method calls in methods upperBound() and lowerBound() in ArrayNumberSequence and LinkedNumberSequence that caused extra time spent on each call.

## Related Issue

Closes #7 

## Changes

Removed if-statements that called isDecreasing() and isIncreasing() which caused an extra loop-through of the lists when upperBound() and lowerBound() were called.

## Screenshots

### Old code:
![code1](https://github.com/LukeyBit/KTH-Programming-1/assets/11096171/29dfce6a-d992-436f-8792-dc73f6eee820)

### New code:
![code2](https://github.com/LukeyBit/KTH-Programming-1/assets/11096171/2741a29c-e1d9-45e5-8559-8c3ddd285c92)


## Checklist

- [x] I have read and agreed to follow the [Code of Conduct](../../CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contribution](../../.github/CONTRIBUTING.md) guidelines.
- [x] I have tested the changes made to the codebase.

## Mentions

@LukeyBit 